### PR TITLE
chore: Fix dockerize workflow step

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -152,7 +152,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: ${{ github.event.repository.name }}
         run: |
-          ./gradlew bootBuildImage --imageName=$ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
+          ./gradlew bootBuildImage -x bootJar --imageName=$ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }}
           docker tag $ECR_REGISTRY/$ECR_REPOSITORY:${{ github.sha }} $ECR_REGISTRY/$ECR_REPOSITORY:latest
           docker push $ECR_REGISTRY/$ECR_REPOSITORY
 


### PR DESCRIPTION
The dockerize step is attempting to build the JAR, but should reuse the
downloaded artifact. Add the `-x bootJar` flag to make Gradle skip
rebuilding the jar file.

TISNEW-4972