### PR TITLE
feat: Add endpoint to get environment details

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "uk.nhs.hee.tis.revalidation"
-version = "0.2.0"
+version = "0.3.0"
 sourceCompatibility = "11"
 
 configurations {

--- a/src/main/java/uk/nhs/hee/tis/revalidation/core/controller/EnvironmentController.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/core/controller/EnvironmentController.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.core.controller;
+
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import uk.nhs.hee.tis.revalidation.core.dto.EnvironmentDto;
+import uk.nhs.hee.tis.revalidation.core.service.EnvironmentService;
+
+@RestController
+@RequestMapping("/api/environment")
+public class EnvironmentController {
+
+  private final EnvironmentService service;
+
+  EnvironmentController(EnvironmentService service) {
+    this.service = service;
+  }
+
+  @ApiOperation(value = "Get the details of the environment the service is being ran on")
+  @ApiResponse(code = 200, message = "Environment details", response = String.class)
+  @GetMapping
+  public ResponseEntity<EnvironmentDto> getEnvironmentDetails() {
+    return ResponseEntity.ok(service.getEnvironmentDetails());
+  }
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/core/dto/EnvironmentDto.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/core/dto/EnvironmentDto.java
@@ -1,0 +1,32 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.core.dto;
+
+import lombok.Data;
+import lombok.NonNull;
+
+@Data
+public class EnvironmentDto {
+
+  @NonNull
+  private String name;
+}

--- a/src/main/java/uk/nhs/hee/tis/revalidation/core/service/EnvironmentService.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/core/service/EnvironmentService.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.core.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import uk.nhs.hee.tis.revalidation.core.dto.EnvironmentDto;
+
+@Service
+public class EnvironmentService {
+
+  @Value("${app.environment.name}")
+  private String environmentName;
+
+  public EnvironmentDto getEnvironmentDetails() {
+    return new EnvironmentDto(environmentName);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,9 @@ app:
     admin-group: ${ADMIN_GROUP:}
     admin-user-pool: ${ADMIN_USER_POOL:}
 
+  environment:
+    name: ${SENTRY_ENVIRONMENT:local}
+
   error:
     exchange: "ex.error"
     limit.retries: true

--- a/src/test/java/uk/nhs/hee/tis/revalidation/core/controller/EnvironmentControllerTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/core/controller/EnvironmentControllerTest.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.core.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.nhs.hee.tis.revalidation.core.dto.EnvironmentDto;
+import uk.nhs.hee.tis.revalidation.core.service.EnvironmentService;
+
+@ExtendWith(MockitoExtension.class)
+@WebMvcTest(EnvironmentController.class)
+class EnvironmentControllerTest {
+
+  private final MockMvc mockMvc;
+
+  @MockBean
+  private EnvironmentService service;
+
+  @Autowired
+  EnvironmentControllerTest(MockMvc mockMvc) {
+    this.mockMvc = mockMvc;
+  }
+
+  @Test
+  void shouldGetEnvironmentDetails() throws Exception {
+    when(service.getEnvironmentDetails()).thenReturn(new EnvironmentDto("test"));
+
+    mockMvc.perform(get("/api/environment"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("name").value("test"));
+  }
+}

--- a/src/test/java/uk/nhs/hee/tis/revalidation/core/service/EnvironmentServiceTest.java
+++ b/src/test/java/uk/nhs/hee/tis/revalidation/core/service/EnvironmentServiceTest.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2020 Crown Copyright (Health Education England)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package uk.nhs.hee.tis.revalidation.core.service;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import uk.nhs.hee.tis.revalidation.core.dto.EnvironmentDto;
+
+@SpringBootTest(classes = {EnvironmentService.class}, properties = {"app.environment.name=test"})
+class EnvironmentServiceTest {
+
+  private EnvironmentService service;
+
+  @Autowired
+  EnvironmentServiceTest(EnvironmentService service) {
+    this.service = service;
+  }
+
+  @Test
+  void shouldGetEnvironmentDetailsFromProperty() {
+    EnvironmentDto environmentDetails = service.getEnvironmentDetails();
+    assertThat("Unexpected environment name.", environmentDetails.getName(), is("test"));
+  }
+}


### PR DESCRIPTION
An endpoint is required which returns details about the environment the
application is running within, currently only the name should be
returned.

TISNEW-5487