### PR TITLE
chore: Add auto-caching using setup-java action

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -13,9 +13,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v2.3.0
         with:
+          cache: gradle
           distribution: adopt
           java-version: 11
 
@@ -36,9 +37,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v2.3.0
         with:
+          cache: gradle
           distribution: adopt
           java-version: 11
 
@@ -59,9 +61,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v2.3.0
         with:
+          cache: gradle
           distribution: adopt
           java-version: 11
 
@@ -89,9 +92,10 @@ jobs:
           name: reports
           path: build/reports
 
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v2.3.0
         with:
+          cache: gradle
           distribution: adopt
           java-version: 11
 


### PR DESCRIPTION
The `setup-java` action now supports automatic caching of maven and
gradle dependencies, update the workflow to use that caching.

TIS21-2078