### PR TITLE
chore: update version for spring boot and cognito idp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id "java"
-  id "org.springframework.boot" version "2.5.3"
+  id "org.springframework.boot" version "2.5.4"
   id "io.spring.dependency-management" version "1.0.11.RELEASE"
 
   // Code quality plugins
@@ -54,7 +54,7 @@ dependencies {
   implementation "org.glassfish.jaxb:jaxb-runtime"
   implementation "io.springfox:springfox-swagger2:3.0.0"
   implementation "io.springfox:springfox-swagger-ui:3.0.0"
-  implementation "com.amazonaws:aws-java-sdk-cognitoidp:1.12.57"
+  implementation "com.amazonaws:aws-java-sdk-cognitoidp:1.12.66"
 }
 
 checkstyle {


### PR DESCRIPTION
NO TICKET

When Dependabot raised the PR for updating the spring boot and cognito idp version from lower to higher, in the github actions flow we see the "authorization" error for sonar qube. 

So this PR is raised to update those libraries. 

Next step is to check the Dependabot's access and permission in the sonar qube. 