### PR TITLE
fix: remove recommendation queue from core service

### DIFF
--- a/src/main/java/uk/nhs/hee/tis/revalidation/core/messages/RabbitMessageListener.java
+++ b/src/main/java/uk/nhs/hee/tis/revalidation/core/messages/RabbitMessageListener.java
@@ -34,10 +34,4 @@ public class RabbitMessageListener {
 
   @Autowired
   private DoctorsForDbService doctorsForDbService;
-
-  @RabbitListener(queues = "${app.rabbit.queue}")
-  public void receivedMessage(final DoctorsForDbDto gmcDoctor) {
-    log.info("Message received from rabbit: {}", gmcDoctor);
-    doctorsForDbService.updateTrainee(gmcDoctor);
-  }
 }


### PR DESCRIPTION
This queue is listening to some messages which are not aimed for it. We will need some tech debt ticket to go for a permanent solution.