### PR TITLE
chore: migrate from adopt to temurin in workflows

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/setup-java@v3.1.0
         with:
           cache: gradle
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Build with Gradle
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-java@v3.1.0
         with:
           cache: gradle
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Run Gradle checks
@@ -67,7 +67,7 @@ jobs:
         uses: actions/setup-java@v3.1.0
         with:
           cache: gradle
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Run Gradle tests
@@ -98,7 +98,7 @@ jobs:
         uses: actions/setup-java@v3.1.0
         with:
           cache: gradle
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Run quality analysis


### PR DESCRIPTION
The AdoptOpenJDK project has moved and rebranded to Adoptium, with
Temurin being the naming of the JDK binaries produced by the Adoptium
project.

TIS21-SHED